### PR TITLE
Check defined-ness instead of truth in intersection()

### DIFF
--- a/lib/Number/Tolerant.pm
+++ b/lib/Number/Tolerant.pm
@@ -296,7 +296,7 @@ sub intersection {
   if (defined $_[0]->{min} and defined $_[1]->{min}) {
     ($min) = sort {$b<=>$a}  ($_[0]->{min}, $_[1]->{min});
   } else {
-    $min = $_[0]->{min} || $_[1]->{min};
+    $min = defined $_[0]->{min} ? $_[0]->{min} : $_[1]->{min};
   }
 
   $exclude_min = 1
@@ -306,7 +306,7 @@ sub intersection {
   if (defined $_[0]->{max} and defined $_[1]->{max}) {
     ($max) = sort {$a<=>$b} ($_[0]->{max}, $_[1]->{max});
   } else {
-    $max = $_[0]->{max} || $_[1]->{max};
+    $max = defined $_[0]->{max} ? $_[0]->{max} : $_[1]->{max};
   }
 
   $exclude_max = 1

--- a/t/and_tolerance.t
+++ b/t/and_tolerance.t
@@ -250,3 +250,37 @@ BEGIN { use_ok("Number::Tolerant"); }
   is($range->{min},      undef, ' ... minimum : undef');
   is($range->{max},      undef, ' ... maximum : undef');
 }
+
+{ # min = 0 for first limit
+  my $demand = Number::Tolerant->new(0 => 'or_more');
+  my $offer  = Number::Tolerant->new(10 => 'or_less');
+
+  isa_ok($demand, 'Number::Tolerant');
+  isa_ok($offer,  'Number::Tolerant');
+
+  my $range = $demand & $offer;
+
+  isa_ok($range,   'Number::Tolerant', 'intersection');
+
+  is("$range", '0 <= x <= 10', ' ... stringifies');
+
+  is($range->{min},       0, ' ... minimum :  0');
+  is($range->{max},      10, ' ... maximum : 10');
+}
+
+{ # max = 0 for first limit
+  my $demand = Number::Tolerant->new(0 => 'or_less');
+  my $offer  = Number::Tolerant->new(-5 => 'or_more');
+
+  isa_ok($demand, 'Number::Tolerant');
+  isa_ok($offer,  'Number::Tolerant');
+
+  my $range = $demand & $offer;
+
+  isa_ok($range,   'Number::Tolerant', 'intersection');
+
+  is("$range", '-5 <= x <= 0', ' ... stringifies');
+
+  is($range->{min},      -5, ' ... minimum : -5');
+  is($range->{max},       0, ' ... maximum :  0');
+}


### PR DESCRIPTION
Patch for issue #6 including tests to detect the bug in pre-patched code.
I used `defined x ? x : y` instead of `x // y` because N::T doesn't declare a minimum version and I didn't want to add a dependency on v5.10. (Though N::T does overload `~~`, which was added in v5.10.)